### PR TITLE
Fixed download path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+ # Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ virtualbox_version: 5.0.26
 # the checksum of the iso fil
 iso_checksum: "sha256:7458ee5a7121a7d243fd6a7528ba427945d9120c5efc7cd75b3951fb01f09c59"
 # specifiy where the downloaded iso file will be placed
-iso_download_path: "/opt"
+iso_download_path: "/opt/vboxguest"
 # mount path where iso will mounted
 iso_mount_path: /mnt/virtualbox
 # easier path based on above variables

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: assure {{iso_download_path}} exists
+  file:
+    path: "{{iso_download_path }}"
+    state: directory
+    mode: 0755
+
 # tasks file for ansible-role-virtualbox-guest
 - name: Check if (the requested version of) vboxguestadditions is installed
   shell: modinfo vboxguest 2>/dev/null|awk '/^version/{print $2}'
@@ -79,7 +86,7 @@
       - dkms
       - gcc
       - make
-      - "linux-headers-{{ kernel.stdout }}"
+      - "linux-headers-{{ ansible_kernel }}"
     when: virtualbox_pkg_remove is defined and virtualbox_pkg_remove
 
   - name: Remove build logfiles, artefacts and ISO files


### PR DESCRIPTION
I changed the default for the iso_download_path. With the current setup, this would delete the complete  /opt directory after installation, which includes the just installed virtualbox-guest..

In addition, I fixed the variable name for the kernel
